### PR TITLE
Use a gemspec to prepare for gem releases

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,11 +1,3 @@
 source 'https://rubygems.org'
 
-gem 'puppetdb-ruby', git: 'https://github.com/voxpupuli/puppetdb-ruby', branch: 'master'
-gem 'wash', git: 'https://github.com/puppetlabs/wash-ruby'
-
-group :development do
-  gem 'pry'
-  gem 'ruby-debug-ide'
-  gem 'debase'
-  gem 'rcodetools'
-end
+gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,16 +1,9 @@
-GIT
-  remote: https://github.com/puppetlabs/wash-ruby
-  revision: ab5d9b8504c90152aeb46059c549d3a86ccee6da
+PATH
+  remote: .
   specs:
-    wash (0.1.0)
-
-GIT
-  remote: https://github.com/voxpupuli/puppetdb-ruby
-  revision: ce306366231f7a805a535a857f38e97288bbcea3
-  branch: master
-  specs:
-    puppetdb-ruby (1.1.1)
-      httparty
+    puppetwash (0.1.0)
+      puppetdb-ruby (~> 1.2)
+      wash (~> 0.1)
 
 GEM
   remote: https://rubygems.org/
@@ -30,22 +23,24 @@ GEM
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
+    puppetdb-ruby (1.2.0)
+      httparty
     rake (12.3.3)
     rcodetools (0.8.5.0)
     ruby-debug-ide (0.7.0)
       rake (>= 0.8.1)
+    wash (0.1.1)
 
 PLATFORMS
   ruby
   x86_64-darwin-18
 
 DEPENDENCIES
-  debase
-  pry
-  puppetdb-ruby!
-  rcodetools
-  ruby-debug-ide
-  wash!
+  debase (~> 0.2)
+  pry (~> 0.12)
+  puppetwash!
+  rcodetools (~> 0.8)
+  ruby-debug-ide (~> 0.7)
 
 BUNDLED WITH
    2.0.2

--- a/puppetwash.gemspec
+++ b/puppetwash.gemspec
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+lib = File.expand_path('lib', __dir__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+
+Gem::Specification.new do |spec|
+  spec.name          = "puppetwash"
+  spec.version       = "0.1.0"
+  spec.authors       = ["Puppet"]
+  spec.email         = ["puppet@puppet.com"]
+
+  spec.summary       = "A Wash plugin for Puppet infrastructure"
+  spec.description   = "A Wash plugin for examining Puppet infrastructure nodes such as PuppetDB, Puppet Server, and PE Classifier"
+  spec.homepage      = "https://github.com/puppetlabs/puppetwash"
+  spec.license       = "Apache-2.0"
+  spec.files         = Dir["*.rb"] + ["puppet"]
+  spec.require_paths = ["."]
+
+  spec.required_ruby_version = "~> 2.3"
+
+  spec.add_dependency "puppetdb-ruby", "~> 1.2"
+  spec.add_dependency "wash", "~> 0.1"
+
+  spec.add_development_dependency "pry", "~> 0.12"
+  spec.add_development_dependency "ruby-debug-ide", "~> 0.7"
+  spec.add_development_dependency "debase", "~> 0.2"
+  spec.add_development_dependency "rcodetools", "~> 0.8"
+end


### PR DESCRIPTION
Once a gem version is released, you'll be able to
```
gem install puppetwash
gem which puppetwash
```
and copy that path (switching puppetwash.rb to puppet) into your Wash
config.

Signed-off-by: Michael Smith <michael.smith@puppet.com>